### PR TITLE
change order of aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ const withLinksCreator = (linkableModules, settings) => (nextConfig) => {
         );
 
         config.resolve.alias = {
-          ...config.resolve.alias,
           ...aliases,
+          ...config.resolve.alias,
         };
 
         if (debug) {


### PR DESCRIPTION
use already defined aliases with higher priority otherwise, it won't be possible to override `react` with `preact/compact` and still be able to use this module.